### PR TITLE
#34 - Added Covid Test Form to Patient dashboard 

### DIFF
--- a/src/components/dashboard/PatientDashboard.tsx
+++ b/src/components/dashboard/PatientDashboard.tsx
@@ -20,6 +20,7 @@ import MainContent from '../layout/MainContent';
 import SideBar from '../layout/SideBar';
 import { UserContext } from '../../context/UserContext';
 import AdminCreateAccount from '../../pages/auth/admincreateaccount';
+import UpdateTestResult from '../../pages/auth/patienttestresult';
 
 const style = {
   position: 'absolute' as const,
@@ -37,6 +38,9 @@ function PatientDashboard() {
   const handleOpenQuiz = () => setModalOpen(true);
   const handleClose = () => setModalOpen(false);
   const navigate = useNavigate();
+  const [testOpen, setTestOpen] = React.useState(false);
+  const handleTestOpen = () => setTestOpen(true);
+  const handleTestClose = () => setTestOpen(false);
 
   const { state, update } = React.useContext(UserContext);
 
@@ -44,6 +48,9 @@ function PatientDashboard() {
     <Box sx={{ display: 'flex' }}>
       <CssBaseline />
       <Header title={`Welcome ${state.firstName}`} subtitle="Stay safe">
+        <Button variant="contained" color="info" sx={{ mr: 1 }} onClick={handleTestOpen}>
+          Add Covid-19 Test
+        </Button>
         <Button variant="contained" color="primary" onClick={() => { navigate('/symptomsForm'); }}>
           Ask for Help
         </Button>
@@ -63,6 +70,16 @@ function PatientDashboard() {
         <Typography paragraph>{state.firstName}</Typography>
       </MainContent>
 
+      <Modal
+        open={testOpen}
+        onClose={handleTestClose}
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
+      >
+        <Box sx={style}>
+          <UpdateTestResult handleTestClose={handleTestClose} />
+        </Box>
+      </Modal>
       <Modal
         open={modalOpen}
         onClose={handleClose}

--- a/src/pages/auth/patienttestresult.tsx
+++ b/src/pages/auth/patienttestresult.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormControlLabel,
+  Grid,
+  Radio,
+  RadioGroup,
+  Typography,
+} from '@mui/material';
+
+type Props = {
+    handleTestClose: any;
+  };
+function UpdateTestResult({ handleTestClose }: Props) {
+  const [testType, setTestType] = useState<string>('');
+  const [testResult, setTestResult] = useState<string>('');
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+      }}
+    >
+      <Grid
+        container
+        spacing={0}
+        direction="column"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <Box
+          p={16}
+          sx={{
+            bgcolor: 'primary.contrastText',
+            borderRadius: 2,
+            boxShadow: 6,
+            marginTop: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            padding: 10,
+          }}
+        >
+          <Grid
+            item
+            xs={12}
+            sx={{
+              bgcolor: 'secondary.main',
+              p: 4,
+              mb: 2,
+            }}
+          >
+            <Typography variant="h5">
+              Which test did you take?
+            </Typography>
+            <FormControl>
+              <RadioGroup
+                value={testType}
+                onChange={(event) => setTestType(event.target.value)}
+              >
+                <FormControlLabel value="PCRTest" control={<Radio />} label="PCR Test" />
+                <FormControlLabel value="rapidAntigenTest" control={<Radio />} label="Rapid Antigen Test" />
+                <FormControlLabel value="antibodyTest" control={<Radio />} label="Antibody Test" />
+              </RadioGroup>
+            </FormControl>
+          </Grid>
+          <Grid
+            item
+            xs={12}
+            sx={{
+              bgcolor: 'secondary.main',
+              p: 4,
+              mt: 2,
+            }}
+          >
+            <Typography variant="h5">
+              What was your result?
+            </Typography>
+            <FormControl>
+              <RadioGroup
+                value={testResult}
+                onChange={(event) => setTestResult(event.target.value)}
+              >
+                <FormControlLabel value="positive" control={<Radio />} label="Covid-19 Positive" />
+                <FormControlLabel value="negative" control={<Radio />} label="Covid-19 Negative" />
+              </RadioGroup>
+            </FormControl>
+          </Grid>
+          <Button
+            type="button"
+            onClick={() => {
+              handleTestClose();
+            }}
+            fullWidth
+            variant="contained"
+            sx={{ mt: 3, mb: 2 }}
+          >
+            Submit
+          </Button>
+        </Box>
+      </Grid>
+    </Box>
+  );
+}
+
+export default UpdateTestResult;


### PR DESCRIPTION
## Related Issue
* (#34)

## Proposed Changes (Description)
- Added button for adding a Covid test result to the Patient dashboard
- Added a form for entering Covid test information
- No form validation yet

## What will be affected:
- Changes to the Patient dashboard, new button and modal pop up
- New component in /auth

## Additional Info
- Draft, will continue working on the aesthetics of the form, pushing in order to start the backend

## Screenshots
![Screen Shot 2022-03-02 at 10 47 14 PM](https://user-images.githubusercontent.com/50461308/156492499-ee136a92-7163-4195-9d78-42111b8544cb.png)

## Checklist
- [ ] Tests
- [ ] Documentation
- [ ] Build Successful
- [] Follow Coding Guidelines


